### PR TITLE
Metadata deploy extensions

### DIFF
--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -529,14 +529,12 @@ Metadata.prototype.deploy = function(zipInput, options, callback) {
  * @returns {Metadata~DeployResultLocator}
  */
 Metadata.prototype.cancelDeploy = function(id, callback) {
-  console.log('Canceling deployment for: ' + id);
-  
   var res = this._invoke("cancelDeploy", { String: id });
   return new DeployResultLocator(this, res).thenCall(callback);
 };
 
 /**
- * (Quick) Deploys a recent validated only deployment.
+ * (Quick) Deploys a recent validated deployment.
  *
  * @param {String} id - Async process id returned from previous deploy request
  * @param {Callback.<Metadata~AsyncResult>} [callback] - Callback function

--- a/lib/api/metadata.js
+++ b/lib/api/metadata.js
@@ -522,6 +522,32 @@ Metadata.prototype.deploy = function(zipInput, options, callback) {
 };
 
 /**
+ * Cancels current active deployment.
+ *
+ * @param {String} id - Async process id returned from previous deploy request
+ * @param {Callback.<Metadata~AsyncResult>} [callback] - Callback function
+ * @returns {Metadata~DeployResultLocator}
+ */
+Metadata.prototype.cancelDeploy = function(id, callback) {
+  console.log('Canceling deployment for: ' + id);
+  
+  var res = this._invoke("cancelDeploy", { String: id });
+  return new DeployResultLocator(this, res).thenCall(callback);
+};
+
+/**
+ * (Quick) Deploys a recent validated only deployment.
+ *
+ * @param {String} id - Async process id returned from previous deploy request
+ * @param {Callback.<Metadata~AsyncResult>} [callback] - Callback function
+ * @returns {Metadata~DeployResultLocator}
+ */
+Metadata.prototype.deployRecentValidation = function(id, callback) {
+  var res = this._invoke("deployRecentValidation", { validationId: id });
+  return new DeployResultLocator(this, res).thenCall(callback);
+};
+
+/**
  * Checks the status of declarative metadata call deploy()
  *
  * @param {String} id - Async process id returned from previous deploy request
@@ -798,6 +824,8 @@ inherits(DeployResultLocator, AsyncResultLocator);
 /**
  * @typedef {Object} Metadata~DeployResult
  * @prop {String} id - ID of the component being deployed
+ * @prop {String} cancelBy - ID of the user who cancelled deployment
+ * @prop {String} canceledByName - Name of user who cancelled deployment
  * @prop {Boolean} checkOnly - Indicates whether this deployment is being used to check the validity of the deployed files without making any changes in the organization or not
  * @prop {String} completedDate - Timestamp for when the deployment process ended
  * @prop {String} createdDate - Timestamp for when the deploy() call was received


### PR DESCRIPTION
Hi, these are the missing metadata deploy api calls implemented:

1 - cancelDeploy 
2 - deployRecentValidation